### PR TITLE
Change invite to slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ description: DevComo is a monthly user group Columbia, MO that is focused on dev
         </a>
     </div>
     <div class="cta col-sm-12 col-md-3">
-        <a class="cta-link" href="https://devcomo-slack-invite.herokuapp.com/">
+        <a class="cta-link" href="https://devcomo-invite.circuitsofimagination.com/">
             <div class="cta-icon">
                 <i class="header-icon fa fa-5x fa-comments-o" aria-hidden="true"></i>
             </div>


### PR DESCRIPTION
Change link to https://devcomo-invite.circuitsofimagination.com/

Nabil made this.